### PR TITLE
chore: align all ec-policy.yaml to ec-policy.yml

### DIFF
--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -284,8 +284,8 @@ Let's do that as follows:
 
 [,bash]
 ----
-$ kubectl logs -c step-validate $POD_NAME | yq .policy > ec-policy.yaml
-$ cat ec-policy.yaml
+$ kubectl logs -c step-validate $POD_NAME | yq .policy > ec-policy.yml
+$ cat ec-policy.yml
 ----
 
 [,yaml]
@@ -394,7 +394,7 @@ We'll add the default configuration with some yq commands. (You could also do
 this manually with a text editor.)
 
 The `ec-policy.yml` file is the one we produced earlier with `kubectl logs -c
-step-validate $POD_NAME | yq .policy > ec-policy.yaml`. The data in that file
+step-validate $POD_NAME | yq .policy > ec-policy.yml`. The data in that file
 will be placed under the `spec` key.
 
 [,bash]


### PR DESCRIPTION
In the [getting-started.adoc](https://github.com/enterprise-contract/ec-cookbook/compare/main...cuipinghuo:ec-cookbook:chore_yaml_yml?expand=1#diff-64f47524d36a58349bcd29535b44a276b16be43138b0eb9fdb329297f8c85ac1), both  ec-policy.yaml and ec-policy.yml appear, this chore is to align all the ec-policy yaml files to ec-policy.yml